### PR TITLE
Fix import issue with YoloV5 export models

### DIFF
--- a/models/common.py
+++ b/models/common.py
@@ -538,7 +538,7 @@ class DetectMultiBackend(nn.Module):
     @staticmethod
     def _model_type(p='path/to/model.pt'):
         # Return model type from model path, i.e. path='path/to/model.onnx' -> type=onnx
-        from export import export_formats
+        from yolov5.export import export_formats
         suffixes = list(export_formats().Suffix) + ['.xml']  # export suffixes
         check_suffix(p, suffixes)  # checks
         p = Path(p).name  # eliminate trailing separators


### PR DESCRIPTION
Simple fix for the new YOLOv5 update that change one import. It fix the error:

```
AI-Aimbot\models\common.py", line 541, in _model_type
    from export import export_formats
ModuleNotFoundError: No module named 'export'
```

This error happens when you run `main_tensorrt_gpu.py`.