### PR TITLE
bugfix: fix issue 'cannot import name is_notebook'

### DIFF
--- a/utils/general.py
+++ b/utils/general.py
@@ -27,6 +27,7 @@ from typing import Optional
 from zipfile import ZipFile
 
 import cv2
+import IPython
 import numpy as np
 import pandas as pd
 import pkg_resources as pkg
@@ -136,6 +137,11 @@ def user_config_dir(dir='Ultralytics', env_var='YOLOV5_CONFIG_DIR'):
         path = (path if is_writeable(path) else Path('/tmp')) / dir  # GCP and AWS lambda fix, only /tmp is writeable
     path.mkdir(exist_ok=True)  # make if required
     return path
+
+def is_notebook():
+    # Is environment a Jupyter notebook? Verified on Colab, Jupyterlab, Kaggle, Paperspace
+    ipython_type = str(type(IPython.get_ipython()))
+    return 'colab' in ipython_type or 'zmqshell' in ipython_type
 
 
 CONFIG_DIR = user_config_dir()  # Ultralytics settings dir


### PR DESCRIPTION
Update `utils/general.py` with the function `is_notebook` from new YOLOv5 update.

It fix the error message:
![unknown](https://user-images.githubusercontent.com/18265771/196996399-9183da13-1257-4a10-895a-a3c083dc8364.png)
